### PR TITLE
Add support of 'rebond' and 'withdraw_unbonded' tx types

### DIFF
--- a/src/api/polkadot/common.js
+++ b/src/api/polkadot/common.js
@@ -1,7 +1,7 @@
 // @flow
 
-// camelCase is for bisontrail
-// snake_case for subscan
+// camelCase is for BisonTrails
+// snake_case for Subscan
 
 export const getOperationType = (pallet: string, palletMethod: string) => {
   switch (palletMethod) {
@@ -10,18 +10,25 @@ export const getOperationType = (pallet: string, palletMethod: string) => {
     case "transferKeepAlive":
       return "OUT";
 
+    case "bond":
     case "bond_extra":
     case "bondExtra":
-    case "bond":
-      return "FREEZE";
+    case "rebond":
+        return "BOND";
 
     case "unbond":
-      return "UNFREEZE";
+      return "UNBOND";
 
     case "nominate":
       return "DELEGATE";
 
     case "chill":
+      return "UNDELEGATE";
+  
+    case "withdraw_unbonded":
+    case "withdrawUnbonded":
+      return "WITHDRAW_UNBONDED";
+
     case "payout_stakers":
     case "payoutStakers":
       return "FEES";

--- a/src/api/polkadot/websocket.js
+++ b/src/api/polkadot/websocket.js
@@ -100,7 +100,8 @@ export const getBalances = async (addr: string) =>
         controller,
         stash,
         nonce: json.accountNonce,
-        bondedBalance: BigNumber(json.lockedBalance),
+        lockedBalance: BigNumber(json.lockedBalance),
+        unbondedBalance: BigNumber(0), // TODO
         unbondings: ledgerJSON
           ? ledgerJSON.unlocking.map((unbond) => ({
               amount: BigNumber(unbond.value),

--- a/src/errors.js
+++ b/src/errors.js
@@ -163,3 +163,7 @@ export const PolkadotLowBondedBalance = createCustomErrorClass(
   "PolkadotLowBondedBalance"
 );
 
+export const PolkadotNoUnbondedBalance = createCustomErrorClass(
+  "PolkadotNoUnbondedBalance"
+);
+

--- a/src/errors.js
+++ b/src/errors.js
@@ -158,3 +158,8 @@ export const PolkadotElectionClosed = createCustomErrorClass(
 export const PolkadotNotValidator = createCustomErrorClass(
   "PolkadotNotValidator"
 );
+
+export const PolkadotLowBondedBalance = createCustomErrorClass(
+  "PolkadotLowBondedBalance"
+);
+

--- a/src/families/polkadot/js-buildTransaction.js
+++ b/src/families/polkadot/js-buildTransaction.js
@@ -46,9 +46,23 @@ const buildTransaction = async (a: Account, t: Transaction, txInfo: any) => {
 
     case "unbond":
       transaction = methods.staking.unbond(
-        {
-          value: t.amount.toString(),
-        },
+        { value: t.amount.toString() },
+        txBaseInfo,
+        txOptions
+      );
+      break;
+
+    case "rebond":
+      transaction = methods.staking.rebond(
+        { value: t.amount.toNumber() },
+        txBaseInfo,
+        txOptions
+      );
+      break;
+
+    case "withdrawUnbonded":
+      transaction = methods.staking.withdrawUnbonded(
+        { numSlashingSpans: 0 },
         txBaseInfo,
         txOptions
       );

--- a/src/families/polkadot/serialization.js
+++ b/src/families/polkadot/serialization.js
@@ -11,7 +11,8 @@ export function toPolkadotResourcesRaw(
     controller,
     stash,
     nonce,
-    bondedBalance: r.bondedBalance.toString(),
+    lockedBalance: r.lockedBalance.toString(),
+    unbondedBalance: r.unbondedBalance.toString(),
     unbondings: r.unbondings?.map((u) => ({
       amount: u.amount.toString(),
       completionDate: u.completionDate,
@@ -32,7 +33,8 @@ export function fromPolkadotResourcesRaw(
     controller,
     stash,
     nonce,
-    bondedBalance: BigNumber(r.bondedBalance),
+    lockedBalance: BigNumber(r.lockedBalance),
+    unbondedBalance: BigNumber(r.unbondedBalance),
     unbondings: r.unbondings?.map((u) => ({
       amount: BigNumber(u.amount),
       completionDate: u.completionDate,

--- a/src/families/polkadot/types.js
+++ b/src/families/polkadot/types.js
@@ -6,8 +6,6 @@ import type {
   TransactionCommonRaw,
 } from "../../types/transaction";
 
-export type PolkadotOperationMode = "send" | "bond" | "nominate" | "unbond"
-
 export type RewardDestinationType = "Staked" | "Stash" | "Account" | "Controller"
 
 export type CoreStatics = {};

--- a/src/families/polkadot/types.js
+++ b/src/families/polkadot/types.js
@@ -45,7 +45,8 @@ export type PolkadotResources = {|
   controller: ?string,
   stash: ?string,
   nonce: number,
-  bondedBalance: BigNumber,
+  lockedBalance: BigNumber,
+  unbondedBalance: BigNumber,
   unbondings: ?PolkadotUnbonding[],
   nominations: ?PolkadotNomination[],
 |};
@@ -54,7 +55,8 @@ export type PolkadotResourcesRaw = {|
   controller: ?string,
   stash: ?string,
   nonce: number,
-  bondedBalance: string,
+  lockedBalance: string,
+  unbondedBalance: string,
   unbondings: ?PolkadotUnbondingRaw[],
   nominations: ?PolkadotNominationRaw[],
 |};

--- a/src/operation.js
+++ b/src/operation.js
@@ -96,6 +96,7 @@ export function getOperationAmountNumber(op: Operation): BigNumber {
     case "UNFREEZE":
     case "BOND":
     case "UNBOND":
+    case "WITHDRAW_UNBONDED":
     case "VOTE":
       return op.fee.negated();
     default:

--- a/src/types/operation.js
+++ b/src/types/operation.js
@@ -20,7 +20,7 @@ export type OperationType =
   // POLKADOT
   | "BOND"
   | "UNBOND"
-  | "NOMINATE"
+  | "WITHDRAW_UNBONDED"
   | "SLASH"
 
   // COMPOUND TYPE OPERATIONS
@@ -29,9 +29,7 @@ export type OperationType =
   | "APPROVE"
   | "OPT_IN"
   | "OPT_OUT"
-  | "CLOSE_ACCOUNT"
-  | "SUPPLY"
-  | "REDEEM";
+  | "CLOSE_ACCOUNT";
 
 export type Operation = {
   // unique identifier (usually hash)


### PR DESCRIPTION
- Add support of 'rebond' and 'withdraw_unbonded' tx types from CLI
- Add tests & error cases for getTransactionStatus
- Try to add consistency for operation types for Polkadot: use new BOND, UNBOND and REBOND types, but use existing DELEGATE and UNDELEGATE for nominate and chill tx types (still WIP, can be discussed).