### PR TITLE
Use numSlashingSpans value provided by sidecar

### DIFF
--- a/src/families/polkadot/api/sidecar.js
+++ b/src/families/polkadot/api/sidecar.js
@@ -428,6 +428,7 @@ export const getStakingInfo = async (addr: string) => {
     (sum, lock) => sum.plus(lock.amount),
     BigNumber(0)
   );
+  const numSlashingSpans = Number(stakingInfo?.numSlashingSpans || 0);
 
   return {
     controller: controller || null,
@@ -435,6 +436,7 @@ export const getStakingInfo = async (addr: string) => {
     unlockedBalance,
     unlockingBalance,
     unlockings,
+    numSlashingSpans
   };
 };
 

--- a/src/families/polkadot/api/sidecar.js
+++ b/src/families/polkadot/api/sidecar.js
@@ -436,7 +436,7 @@ export const getStakingInfo = async (addr: string) => {
     unlockedBalance,
     unlockingBalance,
     unlockings,
-    numSlashingSpans
+    numSlashingSpans,
   };
 };
 

--- a/src/families/polkadot/cache.js
+++ b/src/families/polkadot/cache.js
@@ -43,6 +43,7 @@ const hashTransactionParams = (a: Account, t: Transaction) => {
     case "nominate":
       return `${prefix}_${t.validators?.length ?? "0"}`;
     case "withdrawUnbonded":
+      return `${prefix}_${t.numSlashingSpans}`;
     case "chill":
       return `${prefix}`;
     case "claimReward":

--- a/src/families/polkadot/cli-transaction.js
+++ b/src/families/polkadot/cli-transaction.js
@@ -150,6 +150,7 @@ function inferTransactions(
       validators,
       era: opts.era || null,
       rewardDestination: opts.rewardDestination || null,
+      numSlashingSpans: account.polkadotResources?.numSlashingSpans,
     };
   });
 }

--- a/src/families/polkadot/deviceTransactionConfig.js
+++ b/src/families/polkadot/deviceTransactionConfig.js
@@ -51,7 +51,7 @@ function getDeviceTransactionConfig({
   transaction: Transaction,
   status: TransactionStatus,
 }): Array<DeviceTransactionField> {
-  const { mode, recipient, rewardDestination } = transaction;
+  const { mode, recipient, rewardDestination, numSlashingSpans } = transaction;
   const { amount } = status;
   const mainAccount = getMainAccount(account, parentAccount);
 
@@ -172,6 +172,12 @@ function getDeviceTransactionConfig({
         type: "text",
         label: "Staking",
         value: "Withdraw Unbonded",
+      });
+
+      fields.push({
+        type: "text",
+        label: "Num slashing span",
+        value: numSlashingSpans,
       });
       break;
 

--- a/src/families/polkadot/js-buildTransaction.js
+++ b/src/families/polkadot/js-buildTransaction.js
@@ -76,7 +76,7 @@ const getExtrinsicParams = (a: Account, t: Transaction) => {
       return {
         pallet: "staking",
         name: "withdrawUnbonded",
-        args: { numSlashingSpans: 0 },
+        args: { numSlashingSpans: a.polkadotResources?.numSlashingSpans || 0 },
       };
 
     case "nominate":

--- a/src/families/polkadot/js-createTransaction.js
+++ b/src/families/polkadot/js-createTransaction.js
@@ -17,6 +17,7 @@ const createTransaction = (): Transaction => ({
   validators: [],
   era: null,
   rewardDestination: null,
+  numSlashingSpans: Number(0),
 });
 
 export default createTransaction;

--- a/src/families/polkadot/js-synchronisation.js
+++ b/src/families/polkadot/js-synchronisation.js
@@ -24,6 +24,7 @@ const getAccountShape: GetAccountShape = async (info) => {
     unlockingBalance,
     unlockings,
     nominations,
+    numSlashingSpans,
   } = await getAccount(address);
   const newOperations = await getOperations(id, address, startAt);
   const operations = mergeOps(oldOperations, newOperations);
@@ -43,6 +44,7 @@ const getAccountShape: GetAccountShape = async (info) => {
       unlockingBalance,
       unlockings,
       nominations,
+      numSlashingSpans,
     },
   };
 

--- a/src/families/polkadot/test-dataset.js
+++ b/src/families/polkadot/test-dataset.js
@@ -92,6 +92,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: [],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 amount: BigNumber("100000000"),
@@ -113,6 +114,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: [],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 errors: {
@@ -132,6 +134,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: [],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 errors: {
@@ -151,6 +154,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: [],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 errors: {
@@ -170,6 +174,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: [],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 errors: {
@@ -189,6 +194,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: [],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 amount: BigNumber("10000000000"),
@@ -223,6 +229,7 @@ const dataset: DatasetTest<Transaction> = {
                 ],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 errors: {
@@ -242,6 +249,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: [],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 errors: {
@@ -261,6 +269,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: null,
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 errors: {},
@@ -279,6 +288,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: null,
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 errors: {
@@ -298,6 +308,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: [],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 amount: BigNumber("10000000000"),
@@ -329,6 +340,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: [],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 errors: {
@@ -348,6 +360,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: [],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 errors: {
@@ -367,6 +380,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: [],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 errors: {
@@ -410,6 +424,7 @@ const dataset: DatasetTest<Transaction> = {
                 ],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 errors: {
@@ -429,6 +444,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: [],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 errors: {
@@ -448,6 +464,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: [],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 errors: {
@@ -467,6 +484,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: [],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 errors: {
@@ -508,6 +526,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: [],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 errors: {
@@ -527,6 +546,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: [],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 errors: {
@@ -546,6 +566,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: [],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 errors: {
@@ -567,6 +588,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: [],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 errors: {
@@ -586,6 +608,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: [],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 errors: {},
@@ -603,6 +626,7 @@ const dataset: DatasetTest<Transaction> = {
                 validators: [],
                 fees: null,
                 rewardDestination: null,
+                numSlashingSpans: 0,
               }),
               expectedStatus: {
                 errors: {

--- a/src/families/polkadot/transaction.js
+++ b/src/families/polkadot/transaction.js
@@ -38,6 +38,7 @@ export const fromTransactionRaw = (tr: TransactionRaw): Transaction => {
     validators: tr.validators,
     era: tr.era,
     rewardDestination: tr.rewardDestination,
+    numSlashingSpans: tr.numSlashingSpans,
   };
 };
 
@@ -51,6 +52,7 @@ export const toTransactionRaw = (t: Transaction): TransactionRaw => {
     validators: t.validators,
     era: t.era,
     rewardDestination: t.rewardDestination,
+    numSlashingSpans: t.numSlashingSpans,
   };
 };
 

--- a/src/families/polkadot/types.js
+++ b/src/families/polkadot/types.js
@@ -60,6 +60,7 @@ export type PolkadotResourcesRaw = {|
   unlockingBalance: string,
   unlockings: ?PolkadotUnlockingRaw[],
   nominations: ?PolkadotNominationRaw[],
+  numSlashingSpans: number,
 |};
 
 export type Transaction = {|
@@ -70,6 +71,7 @@ export type Transaction = {|
   validators: ?string[],
   era: ?string,
   rewardDestination: ?string,
+  numSlashingSpans: ?number,
 |};
 
 export type TransactionRaw = {|
@@ -80,6 +82,7 @@ export type TransactionRaw = {|
   validators: ?string[],
   era: ?string,
   rewardDestination: ?string,
+  numSlashingSpans: ?number,
 |};
 
 export type PolkadotValidator = {|

--- a/src/families/polkadot/types.js
+++ b/src/families/polkadot/types.js
@@ -48,6 +48,7 @@ export type PolkadotResources = {|
   unlockingBalance: BigNumber,
   unlockings: ?PolkadotUnlocking[],
   nominations: ?PolkadotNomination[],
+  numSlashingSpans: number,
 |};
 
 export type PolkadotResourcesRaw = {|


### PR DESCRIPTION
For the _withdraw unbonded_ transaction, use the `numSlashingSpans` value provided by sidecar instead of a hardcoded 0 (still use 0 as default value).